### PR TITLE
Add initial support for parsing diagnostics

### DIFF
--- a/src/main/java/com/elovirta/dita/DitaParser.java
+++ b/src/main/java/com/elovirta/dita/DitaParser.java
@@ -11,6 +11,7 @@ import net.sf.saxon.Configuration;
 import net.sf.saxon.lib.*;
 import net.sf.saxon.lib.ResourceRequest;
 import net.sf.saxon.s9api.*;
+import org.eclipse.lsp4j.Diagnostic;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xmlresolver.*;
@@ -47,7 +48,7 @@ public class DitaParser {
             if (extension != null && (extension.equals("dita") || extension.equals("ditamap"))) {
               try {
                 var content = Files.readString(Paths.get(uri)).toCharArray();
-                var doc = parseDocument(content, uri);
+                var doc = parseDocument(content, uri).document();
                 return doc.getUnderlyingNode();
               } catch (IOException e) {
                 throw new UncheckedIOException("Failed to read " + request.uri, e);
@@ -69,7 +70,9 @@ public class DitaParser {
     return processor;
   }
 
-  public XdmNode parse(String content, URI uri) {
+  public record ParseResult(XdmNode document, List<Diagnostic> diagnostics) {}
+
+  public ParseResult parse(String content, URI uri) {
     return parseDocument(content.toCharArray(), uri);
   }
 
@@ -86,22 +89,32 @@ public class DitaParser {
     }
   }
 
-  private XdmNode parseDocument(char[] content, URI uri) {
-    var contentWithLocation = addLocation(content);
+  private ParseResult parseDocument(char[] content, URI uri) {
+    //    var contentWithLocation = addLocation(content);
+    char[] contentWithLocation;
+    var serializer = new XmlSerializer();
+    try (CharArrayWriter output = new CharArrayWriter()) {
+      serializer.serialize(content, output);
+      contentWithLocation = output.toCharArray();
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
     try (var in = new CharArrayReader(contentWithLocation)) {
-      return processor.newDocumentBuilder().build(new StreamSource(in, uri.toString()));
+      return new ParseResult(
+          processor.newDocumentBuilder().build(new StreamSource(in, uri.toString())),
+          serializer.getDiagnostics());
     } catch (SaxonApiException e) {
       throw new RuntimeException(e);
     }
   }
 
-  private char[] addLocation(char[] content) {
-    var serializer = new XmlSerializer();
-    try (CharArrayWriter output = new CharArrayWriter()) {
-      serializer.serialize(content, output);
-      return output.toCharArray();
-    } catch (IOException e) {
-      throw new RuntimeException(e);
-    }
-  }
+  //  private char[] addLocation(char[] content) {
+  //    var serializer = new XmlSerializer();
+  //    try (CharArrayWriter output = new CharArrayWriter()) {
+  //      serializer.serialize(content, output);
+  //      return output.toCharArray();
+  //    } catch (IOException e) {
+  //      throw new RuntimeException(e);
+  //    }
+  //  }
 }

--- a/src/main/java/com/elovirta/dita/Utils.java
+++ b/src/main/java/com/elovirta/dita/Utils.java
@@ -72,6 +72,9 @@ public class Utils {
   }
 
   public static Range parseRange(String loc) {
+    if (loc == null || loc.charAt(0) == '-') {
+      return null;
+    }
     var tokens = loc.split("[:\\-]");
 
     return new Range(

--- a/src/main/java/com/elovirta/dita/xml/AbstractXmlFilter.java
+++ b/src/main/java/com/elovirta/dita/xml/AbstractXmlFilter.java
@@ -1,7 +1,13 @@
 package com.elovirta.dita.xml;
 
 import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.Deque;
+import java.util.List;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.DiagnosticSeverity;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
 
 public abstract class AbstractXmlFilter implements XmlLexer {
 
@@ -26,6 +32,8 @@ public abstract class AbstractXmlFilter implements XmlLexer {
   private int peekOffset;
 
   Deque<char[]> elementStack = new ArrayDeque<>();
+
+  private final List<Diagnostic> diagnostics = new ArrayList<>();
 
   public AbstractXmlFilter(XmlLexer parent) {
     this.parent = parent;
@@ -119,12 +127,37 @@ public abstract class AbstractXmlFilter implements XmlLexer {
     return currentOffset;
   }
 
+  public List<Diagnostic> getDiagnostics() {
+    return diagnostics;
+  }
+
+  void diagnostic(String msg, int line, int column, int pos) {
+    Diagnostic diagnostic = new Diagnostic();
+    diagnostic.setMessage(msg);
+    diagnostic.setSeverity(DiagnosticSeverity.Error);
+    // FIXME
+    diagnostic.setRange(new Range(new Position(line, column), new Position(line, column)));
+    // diagnostics.add(diagnostic);
+  }
+
   char[] getPeekText() {
     return peekText;
   }
 
   void setPeekText(char[] peekText) {
     this.peekText = peekText;
+  }
+
+  int getPeekLine() {
+    return peekLine;
+  }
+
+  int getPeekColumn() {
+    return peekColumn;
+  }
+
+  int getPeekOffset() {
+    return peekOffset;
   }
 
   private void setCurrentToken(

--- a/src/main/java/com/elovirta/dita/xml/XmlFilter.java
+++ b/src/main/java/com/elovirta/dita/xml/XmlFilter.java
@@ -27,23 +27,23 @@ public class XmlFilter extends AbstractXmlFilter {
             }
             case ATTR_NAME -> {
               pushToBuffer(TokenType.ATTR_QUOTE, new char[] {'"'}, -1, -1, -1);
+              diagnostic(
+                  "Open quote is expected for attribute",
+                  getPeekLine(),
+                  getPeekColumn(),
+                  getPeekOffset());
               pushPeekToBufferAs(ATTR_VALUE);
               return;
-              //              switch (peek()) {
-              //                case ATTR_QUOTE -> {
-              //                  pushPeekToBuffer();
-              //                }
-              //                default -> {
-              //                  pushToBuffer(TokenType.ATTR_QUOTE, new char[] {'"'}, -1, -1, -2);
-              //                  pushPeekToBuffer();
-              //                }
-              //              }
-              //              return;
             }
             case ELEMENT_END, EMPTY_ELEMENT_END -> {
               pushToBuffer(TokenType.ATTR_QUOTE, new char[] {'"'}, -1, -1, -3);
               pushToBuffer(TokenType.ATTR_QUOTE, new char[] {'"'}, -1, -1, -4);
               pushPeekToBuffer();
+              diagnostic(
+                  "Open quote is expected for attribute",
+                  getPeekLine(),
+                  getPeekColumn(),
+                  getPeekOffset());
               return;
             }
             default -> {
@@ -67,6 +67,11 @@ public class XmlFilter extends AbstractXmlFilter {
             default -> {
               pushToBuffer(TokenType.EQUALS, new char[] {'='}, -1, -1, -5);
               pushPeekToBuffer();
+              diagnostic(
+                  "1 Attribute must be followed by '=' character",
+                  getPeekLine(),
+                  getPeekColumn(),
+                  getPeekOffset());
               return;
             }
           }
@@ -79,6 +84,11 @@ public class XmlFilter extends AbstractXmlFilter {
           }
           default -> {
             pushToBuffer(TokenType.ATTR_QUOTE, new char[] {'"'}, -1, -1, -6);
+            diagnostic(
+                "Close quote is expected for attribute",
+                getPeekLine(),
+                getPeekColumn(),
+                getPeekOffset());
             pushPeekToBuffer();
           }
         }
@@ -86,6 +96,11 @@ public class XmlFilter extends AbstractXmlFilter {
       case ELEMENT_NAME_END -> {
         var stackName = elementStack.peek();
         if (!Arrays.equals(getText(), stackName) && Utils.startsWith(stackName, getText())) {
+          diagnostic(
+              "End element name doesn't match start element name",
+              getLine(),
+              getColumn(),
+              getOffset());
           logger.debug(
               "Correct end tag name from {} to {}",
               String.valueOf(getText()),
@@ -105,6 +120,11 @@ public class XmlFilter extends AbstractXmlFilter {
             default -> {
               pushToBuffer(TokenType.ELEMENT_END, new char[] {'>'}, -1, -1, -7);
               pushPeekToBuffer();
+              diagnostic(
+                  "End element name must be followed by '>' character",
+                  getPeekLine(),
+                  getPeekColumn(),
+                  getPeekOffset());
               return;
             }
           }

--- a/src/main/java/com/elovirta/dita/xml/XmlLexer.java
+++ b/src/main/java/com/elovirta/dita/xml/XmlLexer.java
@@ -1,6 +1,8 @@
 package com.elovirta.dita.xml;
 
 import java.util.Iterator;
+import java.util.List;
+import org.eclipse.lsp4j.Diagnostic;
 
 public interface XmlLexer extends Iterator<XmlLexer.TokenType> {
   enum TokenType {
@@ -65,4 +67,6 @@ public interface XmlLexer extends Iterator<XmlLexer.TokenType> {
   int getColumn();
 
   int getOffset();
+
+  List<Diagnostic> getDiagnostics();
 }

--- a/src/main/java/com/elovirta/dita/xml/XmlLexerImpl.java
+++ b/src/main/java/com/elovirta/dita/xml/XmlLexerImpl.java
@@ -1,6 +1,8 @@
 package com.elovirta.dita.xml;
 
+import java.util.List;
 import java.util.NoSuchElementException;
+import org.eclipse.lsp4j.Diagnostic;
 
 public class XmlLexerImpl implements XmlLexer {
 
@@ -93,6 +95,11 @@ public class XmlLexerImpl implements XmlLexer {
   @Override
   public int getOffset() {
     return currentOffset;
+  }
+
+  @Override
+  public List<Diagnostic> getDiagnostics() {
+    throw new UnsupportedOperationException();
   }
 
   private TokenType nextToken() {

--- a/src/main/java/com/elovirta/dita/xml/XmlSerializer.java
+++ b/src/main/java/com/elovirta/dita/xml/XmlSerializer.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.io.Writer;
 import java.util.*;
+import org.eclipse.lsp4j.Diagnostic;
 
 public class XmlSerializer {
 
@@ -88,6 +89,10 @@ public class XmlSerializer {
     }
 
     writer.flush();
+  }
+
+  public List<Diagnostic> getDiagnostics() {
+    return lexer.getDiagnostics();
   }
 
   private void writeToken() throws IOException {

--- a/src/test/java/com/elovirta/dita/DocumentManagerTest.java
+++ b/src/test/java/com/elovirta/dita/DocumentManagerTest.java
@@ -21,7 +21,7 @@ class DocumentManagerTest {
     try (var in = getClass().getClassLoader().getResourceAsStream("topics/valid.dita")) {
       documentManager = new DocumentManager(new DitaParser());
       var doc = new Processor().newDocumentBuilder().build(new StreamSource(in));
-      documentManager.put(URI.create("file:///topics/valid.dita"), doc);
+      documentManager.put(URI.create("file:///topics/valid.dita"), doc, null);
     } catch (SaxonApiException | IOException e) {
       throw new RuntimeException(e);
     }

--- a/src/test/java/com/elovirta/dita/SubjectSchemeManagerTest.java
+++ b/src/test/java/com/elovirta/dita/SubjectSchemeManagerTest.java
@@ -19,7 +19,7 @@ class SubjectSchemeManagerTest {
     var uri = URI.create("classpath:maps/subjectScheme.ditamap");
     var doc = ditaParser.parse(readResource("/maps/subjectScheme.ditamap"), uri);
     subjectSchemeManager = new SubjectSchemeManager();
-    subjectSchemeManager.read(uri, doc);
+    subjectSchemeManager.read(uri, doc.document());
   }
 
   @Test

--- a/src/test/java/com/elovirta/dita/validator/SchematronValidatorTest.java
+++ b/src/test/java/com/elovirta/dita/validator/SchematronValidatorTest.java
@@ -30,8 +30,9 @@ class SchematronValidatorTest {
   @BeforeEach
   void setUp() {
     doc =
-        parser.parse(
-            """
+        parser
+            .parse(
+                """
             <topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/"
                    ditaarch:DITAArchVersion="1.3"
                    id="topic">
@@ -39,7 +40,8 @@ class SchematronValidatorTest {
              <body/>
             </topic>
             """,
-            URI.create("file:///topic.dita"));
+                URI.create("file:///topic.dita"))
+            .document();
   }
 
   @Test
@@ -56,7 +58,7 @@ class SchematronValidatorTest {
   //    schematronValidator.setSchematron(URI.create("classpath:topic.sch"));
   //    var act = new ArrayList<Diagnostic>();
   //
-  //    schematronValidator.validate(doc, act);
+  //    schematronValidator.validate(document, act);
   //
   //    assertEquals(
   //        List.of(

--- a/src/test/java/com/elovirta/dita/xml/AbstractXmlFilterTest.java
+++ b/src/test/java/com/elovirta/dita/xml/AbstractXmlFilterTest.java
@@ -3,6 +3,8 @@ package com.elovirta.dita.xml;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.elovirta.dita.xml.XmlLexer.TokenType;
+import java.util.List;
+import org.eclipse.lsp4j.Diagnostic;
 import org.junit.jupiter.api.Test;
 
 class AbstractXmlFilterTest {
@@ -137,6 +139,11 @@ class AbstractXmlFilterTest {
     @Override
     public int getOffset() {
       return index;
+    }
+
+    @Override
+    public List<Diagnostic> getDiagnostics() {
+      throw new UnsupportedOperationException();
     }
 
     @Override


### PR DESCRIPTION
Add initial support for parsing diagnostics that allows a lexer or token filter to throw diagnostics messages.